### PR TITLE
Date translator

### DIFF
--- a/timeutils/date_translators.go
+++ b/timeutils/date_translators.go
@@ -1,0 +1,7 @@
+package timeutils
+
+import "time"
+
+type MonthTranslator func(month time.Month) string
+
+type WeekdayTranslator func(weekday time.Weekday) string

--- a/timeutils/english_translators.go
+++ b/timeutils/english_translators.go
@@ -1,0 +1,14 @@
+package timeutils
+
+import (
+	"fmt"
+	"time"
+)
+
+func MonthToEnglish(month time.Month) string {
+	return fmt.Sprintf("%s", month)
+}
+
+func WeekdayToEnglish(weekday time.Weekday) string {
+	return fmt.Sprintf("%s", weekday)
+}

--- a/timeutils/english_translators_test.go
+++ b/timeutils/english_translators_test.go
@@ -1,0 +1,28 @@
+package timeutils
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMonthToEnglish(t *testing.T) {
+	Convey("Given a time.Month", t, func() {
+		month := time.Month(9)
+		Convey("when calling MonthToEnglish", func() {
+			stringMonth := MonthToEnglish(month)
+			So(stringMonth, ShouldEqual, "September")
+		})
+	})
+}
+
+func TestWeekdayToEnglish(t *testing.T) {
+	Convey("Given a time.Weekday", t, func() {
+		weekday := time.Weekday(1)
+		Convey("when calling WeedayToEnglish", func() {
+			stringWeekday := WeekdayToEnglish(weekday)
+			So(stringWeekday, ShouldEqual, "Monday")
+		})
+	})
+}

--- a/timeutils/spanish_translators.go
+++ b/timeutils/spanish_translators.go
@@ -1,0 +1,36 @@
+package timeutils
+
+import "time"
+
+var spanishMonth = map[time.Month]string{
+	time.January:   "Enero",
+	time.February:  "Febrero",
+	time.March:     "Marzo",
+	time.April:     "Abril",
+	time.May:       "Mayo",
+	time.June:      "Junio",
+	time.July:      "Julio",
+	time.August:    "Agosto",
+	time.September: "Septiembre",
+	time.October:   "Octubre",
+	time.November:  "Noviembre",
+	time.December:  "Diciembre",
+}
+
+func MonthToSpanish(month time.Month) string {
+	return spanishMonth[month]
+}
+
+var spanishWeekday = map[time.Weekday]string{
+	time.Monday:    "Lunes",
+	time.Tuesday:   "Martes",
+	time.Wednesday: "Miércoles",
+	time.Thursday:  "Jueves",
+	time.Friday:    "Viernes",
+	time.Saturday:  "Sábado",
+	time.Sunday:    "Domingo",
+}
+
+func WeekdayToSpanish(weekday time.Weekday) string {
+	return spanishWeekday[weekday%7]
+}

--- a/timeutils/spanish_translators_test.go
+++ b/timeutils/spanish_translators_test.go
@@ -1,0 +1,28 @@
+package timeutils
+
+import (
+	"testing"
+	"time"
+
+	. "github.com/smartystreets/goconvey/convey"
+)
+
+func TestMonthToSpanish(t *testing.T) {
+	Convey("Given a time.Month", t, func() {
+		month := time.Month(11)
+		Convey("when calling MonthToSpanish", func() {
+			stringMonth := MonthToSpanish(month)
+			So(stringMonth, ShouldEqual, "Noviembre")
+		})
+	})
+}
+
+func TestWeekdayToSpanish(t *testing.T) {
+	Convey("Given a time.Weekday", t, func() {
+		weekday := time.Weekday(7)
+		Convey("when calling WeekdayToSpanish", func() {
+			stringWeekday := WeekdayToSpanish(weekday)
+			So(stringWeekday, ShouldEqual, "Domingo")
+		})
+	})
+}


### PR DESCRIPTION
# Problem Description
- We needed a way to get the translated weekdays and months to fill metrics report with date ranges in a given language

# Features
- Add MonthTranslator and WeekdayTranslator as function types
- Create MonthToEnglish and WeekdayToEnglish functions to return english value for time.Month and time.Weekday
- Create MonthToSpanish and WeekdayToSpanish functions to return spanish value for time.Month and time.Weekday

# Where this change will be used
- This change will be used when filling report date ranges
![image](https://user-images.githubusercontent.com/53949651/93622530-ed54d780-f9a2-11ea-8b54-f206460d49f8.png)
